### PR TITLE
Fix sensor names

### DIFF
--- a/examples/simpletest.py
+++ b/examples/simpletest.py
@@ -23,7 +23,7 @@
 import Adafruit_DHT
 
 # Sensor should be set to Adafruit_DHT.DHT11,
-# Adafruit_DHT22, or Adafruit_AM2302.
+# Adafruit_DHT.DHT22, or Adafruit_DHT.AM2302.
 sensor = Adafruit_DHT.DHT22
 
 # Example using a Beaglebone Black with DHT sensor


### PR DESCRIPTION
Make the comment match the actual sensor type constants
