### PR TITLE
Detect the beaglebone black platform running Arch Linux

### DIFF
--- a/Adafruit_DHT/platform_detect.py
+++ b/Adafruit_DHT/platform_detect.py
@@ -51,7 +51,9 @@ def platform_detect():
         return BEAGLEBONE_BLACK
     elif plat.lower().find('armv7l-with-glibc2.4') > -1:
         return BEAGLEBONE_BLACK
-    
+    elif plat.lower().find('armv7l-with-arch') > -1:
+        return BEAGLEBONE_BLACK
+
     # Couldn't figure out the platform, just return unknown.
     return UNKNOWN
 


### PR DESCRIPTION
Allows the `Adafruit_DHT` module to detect the Beaglebone Black running Arch Linux.