### PR TITLE
python3: add python3 support for Raspberry Pi

### DIFF
--- a/Adafruit_DHT/Raspberry_Pi.py
+++ b/Adafruit_DHT/Raspberry_Pi.py
@@ -18,8 +18,10 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-import common
-import Raspberry_Pi_Driver as driver
+from __future__ import absolute_import
+
+from . import common
+from . import Raspberry_Pi_Driver as driver
 
 def read(sensor, pin):
 	# Validate pin is a valid GPIO.

--- a/Adafruit_DHT/__init__.py
+++ b/Adafruit_DHT/__init__.py
@@ -18,4 +18,6 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-from common import DHT11, DHT22, AM2302, read, read_retry
+from __future__ import absolute_import
+
+from .common import DHT11, DHT22, AM2302, read, read_retry

--- a/Adafruit_DHT/common.py
+++ b/Adafruit_DHT/common.py
@@ -18,9 +18,11 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
+from __future__ import absolute_import
+
 import time
 
-import platform_detect
+from . import platform_detect
 
 
 # Define error constants.
@@ -45,15 +47,15 @@ def get_platform():
 		# Check for version 1 or 2 of the pi.
 		version = platform_detect.pi_version()
 		if version == 1:
-			import Raspberry_Pi
+			from . import Raspberry_Pi
 			return Raspberry_Pi
 		elif version == 2:
-			import Raspberry_Pi_2
+			from . import Raspberry_Pi_2
 			return Raspberry_Pi_2
 		else:
 			raise RuntimeError('No driver for detected Raspberry Pi version available!')
 	elif plat == platform_detect.BEAGLEBONE_BLACK:
-		import Beaglebone_Black
+		from . import Beaglebone_Black
 		return Beaglebone_Black
 	else:
 		raise RuntimeError('Unknown platform.')

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Python library to read the DHT series of humidity and temperature sensors on a R
 
 Designed specifically to work with the Adafruit DHT series sensors ----> https://www.adafruit.com/products/385
 
-Currently the library is only tested with Python 2.6/2.7.
+Currently the library is only tested with Python 2.6/2.7. Raspberry Pi support is also tested on python3.
 
 For all platforms (Raspberry Pi and Beaglebone Black) make sure your system is able to compile Python extensions.  On Raspbian or Beaglebone Black's Debian/Ubuntu image you can ensure your system is ready by executing:
 

--- a/examples/AdafruitDHT.py
+++ b/examples/AdafruitDHT.py
@@ -19,6 +19,8 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
+from __future__ import print_function
+
 import sys
 
 import Adafruit_DHT
@@ -32,8 +34,8 @@ if len(sys.argv) == 3 and sys.argv[1] in sensor_args:
 	sensor = sensor_args[sys.argv[1]]
 	pin = sys.argv[2]
 else:
-	print 'usage: sudo ./Adafruit_DHT.py [11|22|2302] GPIOpin#'
-	print 'example: sudo ./Adafruit_DHT.py 2302 4 - Read from an AM2302 connected to GPIO #4'
+	print('usage: sudo ./Adafruit_DHT.py [11|22|2302] GPIOpin#')
+	print('example: sudo ./Adafruit_DHT.py 2302 4 - Read from an AM2302 connected to GPIO #4')
 	sys.exit(1)
 
 # Try to grab a sensor reading.  Use the read_retry method which will retry up
@@ -48,7 +50,7 @@ humidity, temperature = Adafruit_DHT.read_retry(sensor, pin)
 # guarantee the timing of calls to read the sensor).  
 # If this happens try again!
 if humidity is not None and temperature is not None:
-	print 'Temp={0:0.1f}*  Humidity={1:0.1f}%'.format(temperature, humidity)
+	print('Temp={0:0.1f}*  Humidity={1:0.1f}%'.format(temperature, humidity))
 else:
-	print 'Failed to get reading. Try again!'
+	print('Failed to get reading. Try again!')
 	sys.exit(1)

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 from ez_setup import use_setuptools
 use_setuptools()
 from setuptools import setup, find_packages, Extension
@@ -58,7 +60,7 @@ elif platform == 'TEST':
 								["source/_Test_Driver.c", "source/Test/test_dht_read.c"],
 								extra_compile_args=['-std=gnu99']))
 else:
-	print 'Could not detect if running on the Raspberry Pi or Beaglebone Black.  If this failure is unexpected, you can run again with --force-pi or --force-bbb parameter to force using the Raspberry Pi or Beaglebone Black respectively.'
+	print('Could not detect if running on the Raspberry Pi or Beaglebone Black.  If this failure is unexpected, you can run again with --force-pi or --force-bbb parameter to force using the Raspberry Pi or Beaglebone Black respectively.')
 	sys.exit(1)
 
 # Call setuptools setup function to install package.

--- a/source/_Raspberry_Pi_Driver.c
+++ b/source/_Raspberry_Pi_Driver.c
@@ -38,6 +38,29 @@ static PyObject* Raspberry_Pi_Driver_read(PyObject *self, PyObject *args)
 
 // Boilerplate python module method list and initialization functions below.
 
+#if PY_MAJOR_VERSION >= 3
+
+static PyMethodDef module_methods[] = {
+    {"read", Raspberry_Pi_Driver_read, METH_VARARGS, "Read DHT sensor value on a Raspberry Pi."},
+    {NULL, NULL, 0, NULL}
+};
+
+static struct PyModuleDef raspberry_pi_module = {
+   PyModuleDef_HEAD_INIT,
+   "Raspberry_Pi_Driver",
+   NULL,
+   -1,
+   module_methods
+};
+
+PyMODINIT_FUNC
+PyInit_Raspberry_Pi_Driver(void)
+{
+    return PyModule_Create(&raspberry_pi_module);
+}
+
+#else
+
 static PyMethodDef module_methods[] = {
     {"read", Raspberry_Pi_Driver_read, METH_VARARGS, "Read DHT sensor value on a Raspberry Pi."},
     {NULL, NULL, 0, NULL}
@@ -47,3 +70,5 @@ PyMODINIT_FUNC initRaspberry_Pi_Driver(void)
 {
     Py_InitModule("Raspberry_Pi_Driver", module_methods);
 }
+
+#endif


### PR DESCRIPTION
Make the Raspberry Pi code portable between python2 and python3.