### PR TITLE
fix for compile-error in Test.py

### DIFF
--- a/Adafruit_DHT/Test.py
+++ b/Adafruit_DHT/Test.py
@@ -19,7 +19,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 from . import common
-import .Test_Driver as driver
+import Test_Driver as driver
 
 def read(sensor, pin):
     # Get a reading from C driver code.


### PR DESCRIPTION
Fixing this error when installing:
```
byte-compiling build/bdist.linux-armv6l/egg/Adafruit_DHT/Test.py to Test.pyc
  File "build/bdist.linux-armv6l/egg/Adafruit_DHT/Test.py", line 22
    import .Test_Driver as driver
           ^
SyntaxError: invalid syntax
```