### PR TITLE
Update pi_2_dht_read.c

### DIFF
--- a/source/Raspberry_Pi_2/pi_2_dht_read.c
+++ b/source/Raspberry_Pi_2/pi_2_dht_read.c
@@ -60,7 +60,7 @@ int pi_2_dht_read(int type, int pin, float* humidity, float* temperature) {
 
   // Set pin high for ~500 milliseconds.
   pi_2_mmio_set_high(pin);
-  sleep_milliseconds(500);
+  sleep_milliseconds(2000);
 
   // The next calls are timing critical and care should be taken
   // to ensure no unnecssary work is done below.
@@ -72,7 +72,7 @@ int pi_2_dht_read(int type, int pin, float* humidity, float* temperature) {
   // Set pin at input.
   pi_2_mmio_set_input(pin);
   // Need a very short delay before reading pins or else value is sometimes still low.
-  for (volatile int i = 0; i < 50; ++i) {
+  for (volatile int i = 0; i < 100; ++i) {
   }
 
   // Wait for DHT to pull pin low.


### PR DESCRIPTION
Hi, I've been testing some changes to this code base to resolve some reliability issues with an AM2302 on a Raspberry Pi 2.  I was having to sample 40 times and take the median to get a value that was mostly reliable.  This was much better on a short cable run than a long cable run.  After making the adjustments below I now get reliable values every time (although I'm still sampling 11 times just in case I have not seen an anomaly yet).  The first change may not be necessary, but I've left it in there.

These changes significantly improve the reliability of reading temperature and humidity settings on a Raspberry Pi 2.  

Resolved: Incorrect readings caused by premature detection of DHT pull low.
Resolved: Improved reliability on longer cables - this code is now reliable over a 10m cat5e cable @ 3.3V.
