### PR TITLE
removed SignedJwtAssertionCredentials

### DIFF
--- a/examples/google_spreadsheet.py
+++ b/examples/google_spreadsheet.py
@@ -2,7 +2,7 @@
 
 # Google Spreadsheet DHT Sensor Data-logging Example
 
-# Depends on the 'gspread' and 'oauth2client' package being installed.  If you 
+# Depends on the 'gspread' and 'oauth2client' package being installed.  If you
 # have pip installed execute:
 #   sudo pip install gspread oauth2client
 
@@ -40,7 +40,7 @@ import datetime
 
 import Adafruit_DHT
 import gspread
-from oauth2client.client import SignedJwtAssertionCredentials
+from oauth2client.service_account import ServiceAccountCredentials
 
 # Type of sensor, can be Adafruit_DHT.DHT11, Adafruit_DHT.DHT22, or Adafruit_DHT.AM2302.
 DHT_TYPE = Adafruit_DHT.DHT22
@@ -79,53 +79,52 @@ FREQUENCY_SECONDS      = 30
 
 
 def login_open_sheet(oauth_key_file, spreadsheet):
-	"""Connect to Google Docs spreadsheet and return the first worksheet."""
-	try:
-		json_key = json.load(open(oauth_key_file))
-		credentials = SignedJwtAssertionCredentials(json_key['client_email'], 
-													json_key['private_key'], 
-													['https://spreadsheets.google.com/feeds'])
-		gc = gspread.authorize(credentials)
-		worksheet = gc.open(spreadsheet).sheet1
-		return worksheet
-	except Exception as ex:
-		print 'Unable to login and get spreadsheet.  Check OAuth credentials, spreadsheet name, and make sure spreadsheet is shared to the client_email address in the OAuth .json file!'
-		print 'Google sheet login failed with error:', ex
-		sys.exit(1)
+    """Connect to Google Docs spreadsheet and return the first worksheet."""
+        try:
+            json_key = json.load(open(oauth_key_file))
+                credentials = ServiceAccountCredentials.from_json_keyfile_name(GDOCS_OAUTH_JSON, ['https://spreadsheets.google.com/feeds'])
+                
+                gc = gspread.authorize(credentials)
+                worksheet = gc.open(spreadsheet).sheet1
+                return worksheet
+        except Exception as ex:
+            print 'Unable to login and get spreadsheet.  Check OAuth credentials, spreadsheet name, and make sure spreadsheet is shared to the client_email address in the OAuth .json file!'
+                print 'Google sheet login failed with error:', ex
+                sys.exit(1)
 
 
-print 'Logging sensor measurements to {0} every {1} seconds.'.format(GDOCS_SPREADSHEET_NAME, FREQUENCY_SECONDS)
-print 'Press Ctrl-C to quit.'
+print('Logging sensor measurements to {0} every {1} seconds.'.format(GDOCS_SPREADSHEET_NAME, FREQUENCY_SECONDS))
+print('Press Ctrl-C to quit.')
 worksheet = None
 while True:
-	# Login if necessary.
-	if worksheet is None:
-		worksheet = login_open_sheet(GDOCS_OAUTH_JSON, GDOCS_SPREADSHEET_NAME)
+    # Login if necessary.
+    if worksheet is None:
+        worksheet = login_open_sheet(GDOCS_OAUTH_JSON, GDOCS_SPREADSHEET_NAME)
 
-	# Attempt to get sensor reading.
-	humidity, temp = Adafruit_DHT.read(DHT_TYPE, DHT_PIN)
+    # Attempt to get sensor reading.
+    humidity, temp = Adafruit_DHT.read(DHT_TYPE, DHT_PIN)
 
-	# Skip to the next reading if a valid measurement couldn't be taken.
-	# This might happen if the CPU is under a lot of load and the sensor
-	# can't be reliably read (timing is critical to read the sensor).
-	if humidity is None or temp is None:
-		time.sleep(2)
-		continue
+# Skip to the next reading if a valid measurement couldn't be taken.
+# This might happen if the CPU is under a lot of load and the sensor
+# can't be reliably read (timing is critical to read the sensor).
+if humidity is None or temp is None:
+    time.sleep(2)
+        continue
 
-	print 'Temperature: {0:0.1f} C'.format(temp)
-	print 'Humidity:    {0:0.1f} %'.format(humidity)
- 
-	# Append the data in the spreadsheet, including a timestamp
-	try:
-		worksheet.append_row((datetime.datetime.now(), temp, humidity))
-	except:
-		# Error appending data, most likely because credentials are stale.
-		# Null out the worksheet so a login is performed at the top of the loop.
-		print 'Append error, logging in again'
-		worksheet = None
-		time.sleep(FREQUENCY_SECONDS)
-		continue
+    print('Temperature: {0:0.1f} C'.format(temp))
+    print('Humidity:    {0:0.1f} %'.format(humidity))
 
-	# Wait 30 seconds before continuing
-	print 'Wrote a row to {0}'.format(GDOCS_SPREADSHEET_NAME)
-	time.sleep(FREQUENCY_SECONDS)
+# Append the data in the spreadsheet, including a timestamp
+try:
+    worksheet.append_row((datetime.datetime.now(), temp, humidity))
+    except:
+        # Error appending data, most likely because credentials are stale.
+        # Null out the worksheet so a login is performed at the top of the loop.
+        print('Append error, logging in again')
+        worksheet = None
+        time.sleep(FREQUENCY_SECONDS)
+        continue
+
+# Wait 30 seconds before continuing
+print('Wrote a row to {0}'.format(GDOCS_SPREADSHEET_NAME))
+    time.sleep(FREQUENCY_SECONDS)


### PR DESCRIPTION
SignedJwtAssertionCredentials has been replaced with ServiceAccountCredentials due to change in oauth2client
more info here
https://github.com/google/oauth2client/issues/401