### PR TITLE
Fix deprecated SignedJwtAssertionCredentials

### DIFF
--- a/examples/google_spreadsheet.py
+++ b/examples/google_spreadsheet.py
@@ -40,7 +40,7 @@ import datetime
 
 import Adafruit_DHT
 import gspread
-from oauth2client.client import SignedJwtAssertionCredentials
+from oauth2client.service_account import ServiceAccountCredentials
 
 # Type of sensor, can be Adafruit_DHT.DHT11, Adafruit_DHT.DHT22, or Adafruit_DHT.AM2302.
 DHT_TYPE = Adafruit_DHT.DHT22
@@ -81,10 +81,8 @@ FREQUENCY_SECONDS      = 30
 def login_open_sheet(oauth_key_file, spreadsheet):
     """Connect to Google Docs spreadsheet and return the first worksheet."""
     try:
-        json_key = json.load(open(oauth_key_file))
-        credentials = SignedJwtAssertionCredentials(json_key['client_email'],
-                                                    json_key['private_key'],
-                                                    ['https://spreadsheets.google.com/feeds'])
+        scope =  ['https://spreadsheets.google.com/feeds']
+        credentials = ServiceAccountCredentials.from_json_keyfile_name(oauth_key_file, scope)
         gc = gspread.authorize(credentials)
         worksheet = gc.open(spreadsheet).sheet1
         return worksheet


### PR DESCRIPTION
OAuth2's SignedJwtAssertionCredentials deprecated as of Feb 2016.

see: https://github.com/google/oauth2client/issues/401

Simple fix, a class change.

