### PR TITLE
Detect Pi 3 properly on newer kernels

### DIFF
--- a/Adafruit_DHT/common.py
+++ b/Adafruit_DHT/common.py
@@ -50,6 +50,10 @@ def get_platform():
         elif version == 2:
             from . import Raspberry_Pi_2
             return Raspberry_Pi_2
+        elif version == 3:
+            """Use Pi 2 driver even though running on Pi 3"""
+            from . import Raspberry_Pi_2
+            return Raspberry_Pi_2
         else:
             raise RuntimeError('No driver for detected Raspberry Pi version available!')
     elif plat == platform_detect.BEAGLEBONE_BLACK:

--- a/Adafruit_DHT/platform_detect.py
+++ b/Adafruit_DHT/platform_detect.py
@@ -78,13 +78,14 @@ def pi_revision():
 
 
 def pi_version():
-    """Detect the version of the Raspberry Pi.  Returns either 1, 2 or
+    """Detect the version of the Raspberry Pi.  Returns either 1, 2, 3 or
     None depending on if it's a Raspberry Pi 1 (model A, B, A+, B+),
-    Raspberry Pi 2 (model B+), or not a Raspberry Pi.
+    Raspberry Pi 2 (model B+), Raspberry Pi 3 or not a Raspberry Pi.
     """
     # Check /proc/cpuinfo for the Hardware field value.
     # 2708 is pi 1
     # 2709 is pi 2
+    # 2835 is pi 3
     # Anything else is not a pi.
     with open('/proc/cpuinfo', 'r') as infile:
         cpuinfo = infile.read()
@@ -100,6 +101,9 @@ def pi_version():
     elif match.group(1) == 'BCM2709':
         # Pi 2
         return 2
+    elif match.group(1) == 'BCM2835':
+        # Pi 3
+        return 3
     else:
         # Something else, not a pi.
         return None


### PR DESCRIPTION
Somewhere between kernel 4.4.37 and 4.9.3 hardware version reported on my Pi 3 by /proc/cpuinfo changed from BCM2709 to BCM2835. This PR ensures Pi 3 is detected properly, but still uses the same Pi 2 driver.