### PR TITLE
Add fallback for older kernels.

### DIFF
--- a/Adafruit_DHT/Raspberry_Pi.py
+++ b/Adafruit_DHT/Raspberry_Pi.py
@@ -31,7 +31,9 @@ def read(sensor, pin):
         # Signal no result could be obtained, but the caller can retry.
         return (None, None)
     elif result == common.DHT_ERROR_GPIO:
-        raise RuntimeError('Error accessing GPIO.')
+        raise RuntimeError(
+            'Error accessing GPIO. If `/dev/gpiomem` does not exist '
+            'run this program as root or sudo.')
     elif result != common.DHT_SUCCESS:
         # Some kind of error occured.
         raise RuntimeError('Error calling DHT test driver read: {0}'.format(result))

--- a/source/Raspberry_Pi/pi_mmio.c
+++ b/source/Raspberry_Pi/pi_mmio.c
@@ -37,7 +37,15 @@ volatile uint32_t* pi_mmio_gpio = NULL;
 
 int pi_mmio_init(void) {
   if (pi_mmio_gpio == NULL) {
-    int fd = open("/dev/gpiomem", O_RDWR | O_SYNC);
+    int fd;
+
+    // On older kernels user readable /dev/gpiomem might not exists.
+    // Falls back to root-only /dev/mem.
+    if( access( "/dev/gpiomem", F_OK ) != -1 ) {
+      fd = open("/dev/gpiomem", O_RDWR | O_SYNC);
+    } else {
+      fd = open("/dev/mem", O_RDWR | O_SYNC);
+    }
     if (fd == -1) {
       // Error opening /dev/gpiomem.
       return MMIO_ERROR_DEVMEM;


### PR DESCRIPTION
Fixes issues mentioned in: https://github.com/adafruit/Adafruit_Python_DHT/issues/52

This change adds a fallback to GPIO communication like it was before non-root support was implemented: https://github.com/adafruit/Adafruit_Python_DHT/commit/9e8109bb4ab5ec9127e53e792c1f69eddfd2f687

Non-root access still works, but older kernels which don't allow non-root access will still be supported.

The GPIO error message has been updated to provide proper info to the user.

This applies to RaspberryPi 1 models (tested on early B).

edit: can possibly also be applied for model 2, but I am unable to test this.