### PR TITLE
More stable way to detect start of data transmission

### DIFF
--- a/source/Raspberry_Pi_2/pi_2_dht_read.c
+++ b/source/Raspberry_Pi_2/pi_2_dht_read.c
@@ -71,8 +71,15 @@ int pi_2_dht_read(int type, int pin, float* humidity, float* temperature) {
 
   // Set pin at input.
   pi_2_mmio_set_input(pin);
-  // Need a very short delay before reading pins or else value is sometimes still low.
-  for (volatile int i = 0; i < 50; ++i) {
+
+  // Wait for DHT to pull pin high.
+  uint32_t count = 0;
+  while (!pi_2_mmio_input(pin)) {
+    if (++count >= DHT_MAXCOUNT) {
+      // Timeout waiting for response.
+      set_default_priority();
+      return DHT_ERROR_TIMEOUT;
+    }
   }
 
   // Wait for DHT to pull pin low.


### PR DESCRIPTION
Clean solution instead of https://github.com/adafruit/Adafruit_Python_DHT/pull/6/files https://github.com/adafruit/Adafruit_Python_DHT/pull/24/files https://github.com/adafruit/Adafruit_Python_DHT/pull/46/files

I tested it during several days with short and long (10m) cables.
