### PR TITLE
Prepare for upload to PyPI

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include README.md
+recursive-include source *

--- a/setup.py
+++ b/setup.py
@@ -7,10 +7,14 @@ except ImportError:
     pass
 
 from setuptools import setup, find_packages, Extension
+import os
 import sys
 
 import Adafruit_DHT.platform_detect as platform_detect
 
+
+def read(fname):
+    return open(os.path.join(os.path.dirname(__file__), fname)).read()
 
 # Check if an explicit platform was chosen with a command line parameter.
 # Kind of hacky to manipulate the argument list before calling setup, but it's
@@ -37,7 +41,9 @@ else:
 
 # Pick the right extension to compile based on the platform.
 extensions = []
-if platform == platform_detect.RASPBERRY_PI:
+if 'sdist' in sys.argv:
+    print('Skipped loading platform-specific extensions for Adafruit_DHT (we are generating a cross-platform source distribution).')
+elif platform == platform_detect.RASPBERRY_PI:
     # Get the Pi version (1 or 2)
     if pi_version is None:
         pi_version = platform_detect.pi_version()
@@ -87,6 +93,7 @@ setup(name              = 'Adafruit_DHT',
       author            = 'Tony DiCola',
       author_email      = 'tdicola@adafruit.com',
       description       = 'Library to get readings from the DHT11, DHT22, and AM2302 humidity and temperature sensors on a Raspberry Pi or Beaglebone Black.',
+      long_description  = read('README.md'),
       license           = 'MIT',
       classifiers       = classifiers,
       url               = 'https://github.com/adafruit/Adafruit_Python_DHT/',

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,23 @@ import sys
 import Adafruit_DHT.platform_detect as platform_detect
 
 
+BINARY_COMMANDS = [
+    'build_ext',
+    'build_clib',
+    'bdist',
+    'bdist_dumb',
+    'bdist_rpm',
+    'bdist_wininst',
+    'bdist_wheel',
+    'install'
+]
+
+
+def is_binary_install():
+    do_binary = [command for command in BINARY_COMMANDS if command in sys.argv]
+    return len(do_binary) > 0
+
+
 def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
 
@@ -41,7 +58,7 @@ else:
 
 # Pick the right extension to compile based on the platform.
 extensions = []
-if 'sdist' in sys.argv:
+if not is_binary_install():
     print('Skipped loading platform-specific extensions for Adafruit_DHT (we are generating a cross-platform source distribution).')
 elif platform == platform_detect.RASPBERRY_PI:
     # Get the Pi version (1 or 2)


### PR DESCRIPTION
Massaged project to enable submission of a source distribution to PyPI. Addresses #19

## Changes
* Added MANIFEST.in
* Modified setup.py to not attempt platform detection for commands like `sdist`, `register` or `upload_docs`. This ensures drivers for all supported platforms are bundled. Platform detection is only required for commands doing compilation such as `bdist_*` or `install`.

Used https://github.com/adafruit/Adafruit_Python_DHT/compare/master...hexdump42:master for reference.

## Testing
Published to test PyPI, and tested on Raspberry Pi 3. To test on other platforms (Pi 1, Beaglebone), run:
```bash
pip install -i https://testpypi.python.org/pypi Adafruit_DHT
```

## Limitations
* Did not update README.md with `pip install ...` instructions. This should be left until it is published.
* Did not convert README to RST format to make it render properly on PyPI. Instructions [here](https://tom-christie.github.io/articles/pypi/#readme), should probably be included in a release script.

## Next
Once merged, register an account on PyPI and configure your `~/.pypirc` as per [here](https://tom-christie.github.io/articles/pypi/#register-with-pypi).

Then upload to PyPI:
```
pip install twine
python setup.py sdist
python setup.py register
twine upload dist/Adafruit_DHT-1.3.2.tar.gz
```
