### PR TITLE
Improve error message

### DIFF
--- a/examples/AdafruitDHT.py
+++ b/examples/AdafruitDHT.py
@@ -32,8 +32,8 @@ if len(sys.argv) == 3 and sys.argv[1] in sensor_args:
     sensor = sensor_args[sys.argv[1]]
     pin = sys.argv[2]
 else:
-    print('usage: sudo ./Adafruit_DHT.py [11|22|2302] GPIOpin#')
-    print('example: sudo ./Adafruit_DHT.py 2302 4 - Read from an AM2302 connected to GPIO #4')
+    print('Usage: sudo ./Adafruit_DHT.py [11|22|2302] <GPIO pin number>')
+    print('Example: sudo ./Adafruit_DHT.py 2302 4 - Read from an AM2302 connected to GPIO pin #4')
     sys.exit(1)
 
 # Try to grab a sensor reading.  Use the read_retry method which will retry up


### PR DESCRIPTION
IMO `<GPIO pin number>` is clearer than `GPIOpin#`.