### PR TITLE
Update supported python versions in Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Python library to read the DHT series of humidity and temperature sensors on a R
 
 Designed specifically to work with the Adafruit DHT series sensors ----> https://www.adafruit.com/products/385
 
-Currently the library is only tested with Python 2.6/2.7.
+Currently the library is tested with Python 2.6, 2.7, 3.3 and 3.4. It should work with Python greater than 3.4, too.
 
 For all platforms (Raspberry Pi and Beaglebone Black) make sure your system is able to compile Python extensions.  On Raspbian or Beaglebone Black's Debian/Ubuntu image you can ensure your system is ready by executing:
 


### PR DESCRIPTION
As @tdicola stated in his [comment](https://github.com/adafruit/Adafruit_Python_DHT/issues/13#issuecomment-220887885) in #13 the code works for python 3.3/3.4+, too. But Readme.md still says it is only testet for python 2.6 and 2.7.

So if the update for the Readme.md was just forgotten, here it is.
