### PR TITLE
Follow redirects with curl at ez_setup.py

### DIFF
--- a/ez_setup.py
+++ b/ez_setup.py
@@ -205,7 +205,7 @@ def has_powershell():
 download_file_powershell.viable = has_powershell
 
 def download_file_curl(url, target):
-    cmd = ['curl', url, '--silent', '--output', target]
+    cmd = ['curl', url, '--location', '--silent', '--output', target]
     _clean_check(cmd, target)
 
 def has_curl():


### PR DESCRIPTION
This PR fixes the setup, as some python modules such as _setuptools_ are now a redirect.

For example:

https://pypi.python.org/packages/source/s/setuptools/setuptools-4.0.1.zip is now a 301 redirect to https://pypi.org/packages/source/s/setuptools/setuptools-4.0.1.zip

Current _ez_setup.py_ implementation downloads https://pypi.python.org/packages/source/s/setuptools/setuptools-4.0.1.zip which is now a HTML file, and then crashes:
```
pi@raspberrypi:~/Adafruit_Python_DHT $ python setup.py install
Downloading https://pypi.python.org/packages/source/s/setuptools/setuptools-4.0.1.zip
Extracting in /tmp/tmp6NJujO
Traceback (most recent call last):
  File "setup.py", line 4, in <module>
    use_setuptools()
  File "/home/pi/Adafruit_Python_DHT/ez_setup.py", line 140, in use_setuptools
    return _do_download(version, download_base, to_dir, download_delay)
  File "/home/pi/Adafruit_Python_DHT/ez_setup.py", line 120, in _do_download
    _build_egg(egg, archive, to_dir)
  File "/home/pi/Adafruit_Python_DHT/ez_setup.py", line 62, in _build_egg
    with archive_context(archive_filename):
  File "/usr/lib/python2.7/contextlib.py", line 17, in __enter__
    return self.gen.next()
  File "/home/pi/Adafruit_Python_DHT/ez_setup.py", line 100, in archive_context
    with ContextualZipFile(filename) as archive:
  File "/home/pi/Adafruit_Python_DHT/ez_setup.py", line 88, in __new__
    return zipfile.ZipFile(*args, **kwargs)
  File "/usr/lib/python2.7/zipfile.py", line 770, in __init__
    self._RealGetContents()
  File "/usr/lib/python2.7/zipfile.py", line 813, in _RealGetContents
    raise BadZipfile, "File is not a zip file"
zipfile.BadZipfile: File is not a zip file
```
After this patch:
```
pi@raspberrypi:~/Adafruit_Python_DHT $ python setup.py install
Downloading https://pypi.python.org/packages/source/s/setuptools/setuptools-4.0.1.zip
Extracting in /tmp/tmp7HyCt4
Now working in /tmp/tmp7HyCt4/setuptools-4.0.1
Building a Setuptools egg in /home/pi/Adafruit_Python_DHT
/home/pi/Adafruit_Python_DHT/setuptools-4.0.1-py2.7.egg
running install
[....]
```
This PR should fix #96, fix #91 and maybe #92