### PR TITLE
add Pi 3b+ support

### DIFF
--- a/Adafruit_DHT/platform_detect.py
+++ b/Adafruit_DHT/platform_detect.py
@@ -80,12 +80,13 @@ def pi_revision():
 def pi_version():
     """Detect the version of the Raspberry Pi.  Returns either 1, 2, 3 or
     None depending on if it's a Raspberry Pi 1 (model A, B, A+, B+),
-    Raspberry Pi 2 (model B+), Raspberry Pi 3 or not a Raspberry Pi.
+    Raspberry Pi 2 (model B+), Raspberry Pi 3,Raspberry Pi 3 (model B+) or not a Raspberry Pi.
     """
     # Check /proc/cpuinfo for the Hardware field value.
     # 2708 is pi 1
     # 2709 is pi 2
     # 2835 is pi 3
+    # 2837 is pi 3b+
     # Anything else is not a pi.
     with open('/proc/cpuinfo', 'r') as infile:
         cpuinfo = infile.read()
@@ -103,6 +104,9 @@ def pi_version():
         return 2
     elif match.group(1) == 'BCM2835':
         # Pi 3
+        return 3
+    elif match.group(1) == 'BCM2837':
+        # Pi 3b+
         return 3
     else:
         # Something else, not a pi.


### PR DESCRIPTION
add support to Pi 3b+,which use 'BCM2837',build succsess


