### PR TITLE
Fix egg_info and sdist build issue on MS Windows

### DIFF
--- a/Adafruit_DHT/platform_detect.py
+++ b/Adafruit_DHT/platform_detect.py
@@ -24,6 +24,7 @@
 # TODO: Add dependency on Adafruit Python GPIO and use its platform detect
 # functions.
 
+import os
 import platform
 import re
 
@@ -82,6 +83,9 @@ def pi_version():
     None depending on if it's a Raspberry Pi 1 (model A, B, A+, B+),
     Raspberry Pi 2 (model B+), Raspberry Pi 3,Raspberry Pi 3 (model B+) or not a Raspberry Pi.
     """
+    # /proc/cpuinfo is not present, this cannot be a pi
+    if not os.path.exists('/proc/cpuinfo'):
+        return None
     # Check /proc/cpuinfo for the Hardware field value.
     # 2708 is pi 1
     # 2709 is pi 2


### PR DESCRIPTION
The platform detect code is run even if a binary is not being built, however it relies on `/proc/cpuinfo` being present. If it is not, platform_detect will fail with a `FileNotFoundError` rather than returning `platform_detect.UNKNOWN`. This change makes it possible to run the non-binary commands on operating systems other than Linux.

The motivation for this is that Pipenv requires egg_info to be executable to determine dependencies, even if the package is question is specified as a conditional dependency whose conditions are not met on the current host.

This doesn't affect installation directly on a target machine, as if it is running Linux `/proc/cpuinfo` will be present and the old code path will be taken. If it is running a different operating system where `/proc/cpuinfo` is not present then previously `setup.py` would fail with an exception in `pi_version()` but will now fail with an error that the board could not be detected.