### PR TITLE
Update Google Spreadsheets example

### DIFF
--- a/examples/google_spreadsheet.py
+++ b/examples/google_spreadsheet.py
@@ -81,7 +81,7 @@ FREQUENCY_SECONDS      = 30
 def login_open_sheet(oauth_key_file, spreadsheet):
     """Connect to Google Docs spreadsheet and return the first worksheet."""
     try:
-        scope =  ['https://spreadsheets.google.com/feeds']
+        scope =  ['https://spreadsheets.google.com/feeds', 'https://www.googleapis.com/auth/drive']
         credentials = ServiceAccountCredentials.from_json_keyfile_name(oauth_key_file, scope)
         gc = gspread.authorize(credentials)
         worksheet = gc.open(spreadsheet).sheet1

--- a/examples/google_spreadsheet.py
+++ b/examples/google_spreadsheet.py
@@ -115,7 +115,7 @@ while True:
 
     # Append the data in the spreadsheet, including a timestamp
     try:
-        worksheet.append_row((datetime.datetime.now(), temp, humidity))
+        worksheet.append_row((datetime.datetime.now().isoformat(), temp, humidity))
     except:
         # Error appending data, most likely because credentials are stale.
         # Null out the worksheet so a login is performed at the top of the loop.


### PR DESCRIPTION
This updates the code in the Google Spreadsheets example to work with the latest changes to Google's APIs as of June 4, 2019.

Changes:
- Add 'https://www.googleapis.com/auth/drive' to 'scope' to allow the program to interact with Google Drive (see issue #90)
- Add '.isoformat()' to 'worksheet.append_row((datetime.datetime.now().isoformat(), temp, humidity))' to solve problems with 'datetime.datetime' not being JSON serializable. 

This was tested using Python 3.5.3 running on Raspberry Pi 3 B+. I am not aware of any limitations to this change. 

Library versions relevant to this example:
- oauth2client 4.1.3
- gspread 3.1.0
- pyasn1 0.4.5 (required manual update in my setup)
- pyasn1-modules 0.2.5 (required manual update in my setup)