### PR TITLE
Make error detection work when using Fahrenheit.

### DIFF
--- a/examples/AdafruitDHT.py
+++ b/examples/AdafruitDHT.py
@@ -40,14 +40,14 @@ else:
 # to 15 times to get a sensor reading (waiting 2 seconds between each retry).
 humidity, temperature = Adafruit_DHT.read_retry(sensor, pin)
 
-# Un-comment the line below to convert the temperature to Fahrenheit.
-# temperature = temperature * 9/5.0 + 32
-
 # Note that sometimes you won't get a reading and
 # the results will be null (because Linux can't
 # guarantee the timing of calls to read the sensor).
 # If this happens try again!
 if humidity is not None and temperature is not None:
+    # Un-comment the line below to convert the temperature to Fahrenheit.
+    # temperature = temperature * 9/5.0 + 32
+
     print('Temp={0:0.1f}*  Humidity={1:0.1f}%'.format(temperature, humidity))
 else:
     print('Failed to get reading. Try again!')


### PR DESCRIPTION
- This moves the commented out Fahrenheit conversion code to the point after the code validates the returned values. This preserves the `Failed to get reading. Try again!` error message which is never reached due to the `unsupported operand types(s) for *: 'NoneType' and 'int'` exception.

- No known limitations

- Tests have been run and validated