### PR TITLE
Include Raspberrpy Pi 4

### DIFF
--- a/Adafruit_DHT/platform_detect.py
+++ b/Adafruit_DHT/platform_detect.py
@@ -80,12 +80,13 @@ def pi_revision():
 def pi_version():
     """Detect the version of the Raspberry Pi.  Returns either 1, 2, 3 or
     None depending on if it's a Raspberry Pi 1 (model A, B, A+, B+),
-    Raspberry Pi 2 (model B+), Raspberry Pi 3,Raspberry Pi 3 (model B+) or not a Raspberry Pi.
+    Raspberry Pi 2 (model B+), Raspberry Pi 3,Raspberry Pi 3 (model B+), Raspberry Pi 4
+    or not a Raspberry Pi.
     """
     # Check /proc/cpuinfo for the Hardware field value.
     # 2708 is pi 1
     # 2709 is pi 2
-    # 2835 is pi 3
+    # 2835 is pi 3 or pi 4
     # 2837 is pi 3b+
     # Anything else is not a pi.
     with open('/proc/cpuinfo', 'r') as infile:
@@ -103,7 +104,7 @@ def pi_version():
         # Pi 2
         return 2
     elif match.group(1) == 'BCM2835':
-        # Pi 3
+        # Pi 3 or Pi 4
         return 3
     elif match.group(1) == 'BCM2837':
         # Pi 3b+


### PR DESCRIPTION
The Raspberry Pi 4 uses the same Broadcom 2835 as the Raspberry Pi 3.
The module will work on Raspberry Pi 4 without changes, but the comment makes clear why it works.

No code was changed, only the comments, but explain why the code also works on
Raspberry Pi 4.

I checked on my own Raspberry Pi 4 that indeed it has the same Broadcom 2835 as the Raspberry Pi 3 does.